### PR TITLE
Corrección de la práctica 4

### DIFF
--- a/T251_quads/app/src/androidTest/java/es/unizar/eina/T251_quads/OverloadTest.java
+++ b/T251_quads/app/src/androidTest/java/es/unizar/eina/T251_quads/OverloadTest.java
@@ -5,6 +5,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,6 +33,7 @@ public class OverloadTest {
     }
 
     @Test
+    @Ignore("No se trata de una prueba de regresión")
     public void testSobrecarga() {
         boolean falloControlado = false;
         try {

--- a/T251_quads/app/src/androidTest/java/es/unizar/eina/T251_quads/QuadSmokeTest.java
+++ b/T251_quads/app/src/androidTest/java/es/unizar/eina/T251_quads/QuadSmokeTest.java
@@ -1,5 +1,8 @@
 package es.unizar.eina.T251_quads;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -10,12 +13,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import es.unizar.eina.T251_quads.database.Quad;
-import es.unizar.eina.T251_quads.database.QuadRepository;
 import es.unizar.eina.T251_quads.ui.QuadListActivity;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
 public class QuadSmokeTest {
@@ -25,16 +23,10 @@ public class QuadSmokeTest {
     public ActivityScenarioRule<QuadListActivity> scenarioRule =
             new ActivityScenarioRule<>(QuadListActivity.class);
 
-    private QuadRepository repository;
     private Quad testQuad;
 
     @Before
     public void setUp() {
-        // Accedemos a la actividad para obtener el repositorio
-        scenarioRule.getScenario().onActivity(activity -> {
-            repository = activity.getQuadRepository();
-        });
-        
         // Creamos un quad de prueba
         testQuad = new Quad("9999TST", "Deportivo", 45.5f, "Quad para pruebas de humo");
     }
@@ -43,36 +35,40 @@ public class QuadSmokeTest {
     @Test
     public void testCreationIncreasesNumberOfQuads() {
         // Averiguar el número de quads
-        int quadsIniciales = repository.getNumQuads();
+        scenarioRule.getScenario().onActivity(activity -> {
+            int quadsIniciales = activity.getQuadRepository().getNumQuads();
 
-        // Insertar un nuevo quad
-        long insertId = repository.insert(testQuad);
-        assertTrue("La inserción en la BD ha fallado", insertId >= 0);
+            // Insertar un nuevo quad
+            long insertId = activity.getQuadRepository().insert(testQuad);
+            assertTrue("La inserción en la BD ha fallado", insertId >= 0);
 
-        // Comprobar que el nuevo número es una unidad mayor
-        int quadsFinales = repository.getNumQuads();
-        assertEquals("El número total de quads no se ha incrementado en 1", 
-                     quadsIniciales + 1, quadsFinales);
+            // Comprobar que el nuevo número es una unidad mayor
+            int quadsFinales = activity.getQuadRepository().getNumQuads();
+            assertEquals("El número total de quads no se ha incrementado en 1",
+                         quadsIniciales + 1, quadsFinales);
+        });
     }
 
     // Prueba más exhaustiva (inserción y recuperación de campos)
     @Test
     public void testInsertAndRetrieveQuadData() {
-        // Insertar quad
-        repository.insert(testQuad);
+        scenarioRule.getScenario().onActivity(activity -> {
+            // Insertar quad
+            activity.getQuadRepository().insert(testQuad);
 
-        // Recuperar el quad a través de su matrícula
-        Quad quadRecuperado = repository.getQuadByMatricula(testQuad.getMatricula());
+            // Recuperar el quad a través de su matrícula
+            Quad quadRecuperado = activity.getQuadRepository().getQuadByMatricula(testQuad.getMatricula());
 
-        // Comprobaciones exhaustivas de los campos
-        assertEquals("Los quads no coinciden", testQuad, quadRecuperado);
+            // Comprobaciones exhaustivas de los campos
+            assertEquals("Los quads no coinciden", testQuad, quadRecuperado);
+        });
     }
 
     // Método de finalización para limpiar la base de datos
     @After
     public void tearDown() {
-        if (repository != null) {
-            repository.delete(testQuad);
-        }
+        scenarioRule.getScenario().onActivity(activity -> {
+            activity.getQuadRepository().delete(testQuad);
+        });
     }
 }

--- a/T251_quads/app/src/androidTest/java/es/unizar/eina/T251_quads/QuadSmokeTest.java
+++ b/T251_quads/app/src/androidTest/java/es/unizar/eina/T251_quads/QuadSmokeTest.java
@@ -1,7 +1,9 @@
 package es.unizar.eina.T251_quads;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -40,7 +42,7 @@ public class QuadSmokeTest {
 
             // Insertar un nuevo quad
             long insertId = activity.getQuadRepository().insert(testQuad);
-            assertTrue("La inserción en la BD ha fallado", insertId >= 0);
+            assertThat("La inserción en la BD ha fallado", insertId, is(greaterThanOrEqualTo(0L)));
 
             // Comprobar que el nuevo número es una unidad mayor
             int quadsFinales = activity.getQuadRepository().getNumQuads();


### PR DESCRIPTION
Siento proporcionar realimentación sobre la práctica 4 tan tarde. En cualquier caso, considero esta realimentación os puede venir bien con independencia de que podáis tener tiempo o no de aplicarla para la entrega del trabajo.

He realizado comentarios a través de _commits_ asociados a este _pull request_. La forma más útil de revisarlos es viendo los cambios asociados a cada _commit_ individual (haciendo clic sobre él). Cuando los reviséis, podéis hacer un _merge_ de esta rama en vuestra rama ``main``.

Los cambios hechos en algunos _commits_ son solo a modo de ejemplo. En otras partes del código podría seguir dándose el mismo problema ejemplificado en el _commit_ en cuestión. 

No puedo comprobar si la implementación de las pruebas sigue correctamente el diseño de las mismas especificado en el informe de pruebas, puesto que la primera versión informe no contiene el diseño de los casos de prueba (solo hay una tabla que mezcla particiones de equivalencia para los nombres de una reserva con valores a utilizar y supuestos resultados esperados en algún caso de prueba.
